### PR TITLE
BIB-9 Add required DC fields Worthwhile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-# The default version for jettywrapper is no longer 7 with Fedora 3, so we have to set it for
-#  Worthwhile or we would get Fedora 4
-require 'jettywrapper'
-Jettywrapper.hydra_jetty_version = "v7.1.0"
 
 require File.expand_path('../config/application', __FILE__)
+
+# The default version for jettywrapper is no longer 7 with Fedora 3, so we have to set it for
+#  Worthwhile or we would get Fedora 4
+Jettywrapper.hydra_jetty_version = "v7.1.0"
 
 Rails.application.load_tasks
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,13 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+# The default version for jettywrapper is no longer 7 with Fedora 3, so we have to set it for
+#  Worthwhile or we would get Fedora 4
+require 'jettywrapper'
+Jettywrapper.hydra_jetty_version = "v7.1.0"
+
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+

--- a/app/repository_models/biblio_work.rb
+++ b/app/repository_models/biblio_work.rb
@@ -3,4 +3,12 @@
 class BiblioWork < ActiveFedora::Base
   include ::CurationConcern::Work
   include ::CurationConcern::WithBasicMetadata
+
+  def to_solr(solr_doc={}, opts={})
+    super(solr_doc, opts)
+    # TODO Figure out what new fields to write to Solr using following example
+    solr_doc[Solrizer.solr_name('my_title', 'ss')] = self.title
+    return solr_doc
+  end
+
 end

--- a/app/views/curation_concern/base/_attributes.html.erb
+++ b/app/views/curation_concern/base/_attributes.html.erb
@@ -1,0 +1,26 @@
+<table class="table table-striped <%= dom_class(curation_concern) %> attributes">
+  <caption class="table-heading"><h2>Attributes</h2></caption>
+  <thead>
+    <tr><th>Attribute Name</th><th>Values</th></tr>
+  </thead>
+  <tbody>
+  <%= curation_concern_attribute_to_html(curation_concern, :description, 'Abstract') %>
+  <%= curation_concern_attribute_to_html(curation_concern, :creator, 'Creator', { catalog_search_link: true }) %>
+  <%= curation_concern_attribute_to_html(curation_concern, :contributor, 'Contributors', { catalog_search_link: true }) %>
+  <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject", { catalog_search_link: true }) %>
+  <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
+  <%#= curation_concern_attribute_to_html(curation_concern, :bibliographic_citation, "Bibliographic Citation") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :coverage, "Coverage") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :source, "Source") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :language, "Language") %>
+  <tr>
+    <th>Access Rights</th>
+    <td>
+      <%= permission_badge_for(curation_concern) %>
+    </td>
+  </tr>
+  <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :lease_expiration_date, "Lease Expiration Date") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
+  </tbody>
+</table>

--- a/app/views/curation_concern/base/_form_additional_information.html.erb
+++ b/app/views/curation_concern/base/_form_additional_information.html.erb
@@ -1,0 +1,8 @@
+<fieldset class="optional prompt">
+  <legend>Additional Information</legend>
+  <%= f.input :subject,                as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :publisher,              as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :source,                 as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :coverage,                 as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :language,               as: :multi_value, input_html: { class: 'form-control' } %>
+</fieldset>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -18,6 +18,56 @@
 
   <dataDir>${solr.data.dir:}</dataDir>
 
+<updateHandler class="solr.DirectUpdateHandler2">
+
+    <!-- Enables a transaction log, used for real-time get, durability, and
+         and solr cloud replica recovery.  The log can grow as big as
+         uncommitted changes to the index, so use of a hard autoCommit
+         is recommended (see below).
+         "dir" - the target directory for transaction logs, defaults to the
+                solr data directory.  --> 
+    <updateLog>
+      <str name="dir">${solr.ulog.dir:}</str>
+    </updateLog>
+ 
+    <!-- AutoCommit
+
+         Perform a hard commit automatically under certain conditions.
+         Instead of enabling autoCommit, consider using "commitWithin"
+         when adding documents. 
+
+         http://wiki.apache.org/solr/UpdateXmlMessages
+
+         maxDocs - Maximum number of documents to add since the last
+                   commit before automatically triggering a new commit.
+
+         maxTime - Maximum amount of time in ms that is allowed to pass
+                   since a document was added before automatically
+                   triggering a new commit. 
+         openSearcher - if false, the commit causes recent index changes
+           to be flushed to stable storage, but does not cause a new
+           searcher to be opened to make those changes visible.
+
+         If the updateLog is enabled, then it's highly recommended to
+         have some sort of hard autoCommit to limit the log size.
+      -->
+     <autoCommit> 
+       <maxTime>${solr.autoCommit.maxTime:15000}</maxTime> 
+       <openSearcher>false</openSearcher> 
+     </autoCommit>
+
+    <!-- softAutoCommit is like autoCommit except it causes a
+         'soft' commit which only ensures that changes are visible
+         but does not ensure that data is synced to disk.  This is
+         faster and more near-realtime friendly than a hard commit.
+      -->
+
+     <autoSoftCommit> 
+       <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime> 
+     </autoSoftCommit>
+
+  </updateHandler>
+
   <requestHandler name="search" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters can be specified, these
          will be overridden by parameters in the request


### PR DESCRIPTION
This PR adds a number of things that allows for adding metadata fields specific to a bibliographic resource. The biggest underlying addition is a new "works" type called BiblioWork. As an example for how to extend, a couple of DC fields were added to the entry form and detail view. 

A couple of related things are also resolved: the autoCommit directives were missing from the Solr configuration, resulting in lost index data on restart, and also the correct version of Jetty with Fedora3 is now locked in with a directive in the Rakefile.

Additionally, the to_solr method was added to the new model to show how we can write anything we need into the Solr document for exposure in Spotlight.
