### PR TITLE
BIB-11 Adding more fields to the Solr document for use by Spotlight

### DIFF
--- a/app/repository_models/biblio_work.rb
+++ b/app/repository_models/biblio_work.rb
@@ -7,7 +7,13 @@ class BiblioWork < ActiveFedora::Base
   def to_solr(solr_doc={}, opts={})
     super(solr_doc, opts)
     # TODO Figure out what new fields to write to Solr using following example
-    solr_doc[Solrizer.solr_name('my_title', 'ss')] = self.title
+    solr_doc[Solrizer.solr_name('full_title', 'tesim')] = self.title
+    solr_doc[Solrizer.solr_name('personal_name', 'ssm')] = self.creator
+    solr_doc[Solrizer.solr_name('abstract', 'tesim')] = self.description
+    solr_doc[Solrizer.solr_name('note_desc_note', 'tesim')] = self.contributor
+    solr_doc[Solrizer.solr_name('corporate_name', 'ssm')] = self.publisher
+    solr_doc[Solrizer.solr_name('note_provenance', 'tesim')] = self.coverage
+    solr_doc[Solrizer.solr_name('note_source', 'tesim')] = self.source
     return solr_doc
   end
 


### PR DESCRIPTION
Leftover work from previous sprint that didn't get merged. This adds fields to the BiblioWork type that makes items discoverable in Spotlight.
