### PR TITLE
BIB-51 Deploy to shared demo server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,8 @@
 source 'https://rubygems.org'
 
-#gem 'worthwhile', :git => "https://github.com/projecthydra-labs/worthwhile.git", :ref => '92221695093474702c05699a36373f576d31f8bb'
-#gem 'worthwhile', :path => "/usr/local/rvm/gems/ruby-2.1.5@biblio/bundler/gems/worthwhile-2af43e99fc6d"
-#gem 'worthwhile-models', :path => "/usr/local/rvm/gems/ruby-2.1.5@biblio/bundler/gems/worthwhile-2af43e99fc6d/worthwhile-models"
 gem 'worthwhile'
 gem 'worthwhile-models'
+gem 'thin', '1.6.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     equivalent-xml (0.5.1)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
+    eventmachine (1.0.7)
     execjs (2.3.0)
     extlib (0.9.16)
     faraday (0.9.1)
@@ -426,6 +427,10 @@ GEM
       resque (~> 1.23)
       resque-pool (~> 0.3)
     sxp (0.1.5)
+    thin (1.6.2)
+      daemons (>= 1.0.9)
+      eventmachine (>= 1.0.0)
+      rack (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -473,6 +478,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   spring
   sqlite3
+  thin (= 1.6.2)
   turbolinks
   uglifier (>= 1.3.0)
   worthwhile

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -11,6 +11,8 @@ Sufia.config do |config|
 
   config.max_days_between_audits = 7
 
+  config.minter_statefile = '/tmp/biblio-minter-state'
+
   config.max_notifications_for_dashboard = 5
 
   config.cc_licenses = {


### PR DESCRIPTION
In addition to adding the thin gem, the commit comment should have mentioned overriding the location of config.minter_statefile to avoid collisions with Sufia apps on shared server.
