### PR TITLE
Feature/bib 78 remove navbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 jetty
 
 /.ruby*
+
+# Rubymine files
+*.iml
+.idea/

--- a/Rakefile
+++ b/Rakefile
@@ -3,10 +3,12 @@
 
 # The default version for jettywrapper is no longer 7 with Fedora 3, so we have to set it for
 #  Worthwhile or we would get Fedora 4
-require 'jettywrapper'
-Jettywrapper.hydra_jetty_version = "v7.1.0"
+#require 'jettywrapper'
+#Jettywrapper.hydra_jetty_version = "v7.1.0"
 
 require File.expand_path('../config/application', __FILE__)
+
+Jettywrapper.hydra_jetty_version = "v7.1.0"
 
 Rails.application.load_tasks
 

--- a/app/views/catalog/_navbar.html.erb
+++ b/app/views/catalog/_navbar.html.erb
@@ -1,0 +1,14 @@
+<!--
+<nav class="navbar navbar-default" role="navigation">
+  <div class="container-fluid">
+    <div class="collapse navbar-collapse" id="type-tabs">
+      <ul class="nav navbar-nav">
+        <%= all_type_tab %>
+        <%= type_tab 'Works', 'Work' %>
+        <%= type_tab 'Collections', 'Collection' %>
+      </ul>
+    </div>
+  </div>
+</nav>
+-->
+


### PR DESCRIPTION
Navbar is commented out. This also adds Rubymine files to the .gitignore.
