### PR TITLE
BIB-103: Persisting WorkType definitions to Fedora

### DIFF
--- a/lib/generators/bibliocat/work/work_generator.rb
+++ b/lib/generators/bibliocat/work/work_generator.rb
@@ -71,6 +71,23 @@ class Bibliocat::WorkGenerator < Rails::Generators::NamedBase
     readme 'README'
   end
 
+  def to_fedora
+    # TODO paramatize is_type_of
+    is_type_of = 'BiblioWork'
+    work_type = WorkType.new(registered_name: class_name, display_name: class_name.titleize, is_type_of: is_type_of)
+    begin
+      work_type.schema_file = File.open(Rails.root + "config/locales/#{file_name}.en.yml")
+    rescue
+      puts "No schema found in config/locales/#{file_name}.en.yml"
+      work_type.schema_file = File.open(Rails.root + "config/locales/bibliowork.en.yml")
+    end
+    if work_type.save
+      print "\"#{class_name}\" WorkType saved to Fedora."
+    else
+      puts "ABORTING: problem saving WorkType"
+      puts work_type.errors.messages
+    end
+  end
 
   private
 


### PR DESCRIPTION
This adds a new method to the Bibliocat work generator that uses the registered name of a new work type and creates an object for it in Fedora. It also adds the derived metadata schema file to the object as a datastream.
