### PR TITLE
BIB-52 Removing general IR features from create and edit views

### DIFF
--- a/app/views/curation_concern/base/_form.html.erb
+++ b/app/views/curation_concern/base/_form.html.erb
@@ -1,0 +1,34 @@
+<%= simple_form_for [:curation_concern, curation_concern] do |f| %>
+  
+  <% if f.error_notification -%>
+    <div class="alert alert-danger fade in">
+      <strong>Wait don't go!</strong> There was a problem with your submission. Please review the errors below:
+      <a class="close" data-dismiss="alert" href="#">&times;</a>
+    </div>
+  <% end -%>
+
+  <%= render 'form_descriptive_fields', curation_concern: curation_concern, f: f %>
+
+  <%# These renders originally came from form_supplementary_fields, which we aren't rendering
+      to avoid permissions and license forms. %>
+  <%= render "form_files_and_links", curation_concern: curation_concern, f: f %>
+  <%= render "form_representative_image", curation_concern: curation_concern, f: f %>
+
+  <%# Passing parameters to satisfy requirements for permissions and acceptance %>
+  <fieldset>
+    <input type="hidden" id="visibility_restricted" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE%>"/>
+    <input type="hidden" id="accept_contributor_agreement" name="accept_contributor_agreement" value="accept"/> 
+  </fieldset>
+
+  <div class="row">
+    <div class="col-md-12 form-actions">
+      <%= f.submit class: 'btn btn-primary' %>
+      <%- if curation_concern.new_record? -%>
+        <%= link_to 'Cancel', main_app.root_path, class: 'btn btn-link' %>
+      <%- else -%>
+        <%= link_to 'Cancel', polymorphic_path([:curation_concern, curation_concern]), class: 'btn btn-link' %>
+      <%- end -%>
+    </div>
+  </div>
+
+<% end %>

--- a/app/views/curation_concern/base/edit.html.erb
+++ b/app/views/curation_concern/base/edit.html.erb
@@ -1,0 +1,6 @@
+<% provide :page_title, curation_concern_page_title(curation_concern) %>
+<% provide :page_header do %>
+  <h2>Manage Your <%= curation_concern.human_readable_type %></h2>
+<% end %>
+
+<%= render 'form' %>

--- a/app/views/curation_concern/base/new.html.erb
+++ b/app/views/curation_concern/base/new.html.erb
@@ -1,0 +1,6 @@
+<% provide :page_title, curation_concern_page_title(curation_concern) %>
+<% provide :page_header do %>
+  <h2>Describe Your <%= curation_concern.human_readable_type %></h2>
+<% end %>
+
+<%= render 'form' %>


### PR DESCRIPTION
This PR overrides the main form ERB to avoid forcing the user to choose permissions, license type, and legal acceptance during create/edit.
